### PR TITLE
实现演讲列表快速筛选功能

### DIFF
--- a/apps/web/src/app/(dashboard)/lectures/page-content.tsx
+++ b/apps/web/src/app/(dashboard)/lectures/page-content.tsx
@@ -4,22 +4,21 @@ import { Button } from '@repo/ui/components/button';
 import { Card, CardContent } from '@repo/ui/components/card';
 import { Plus, Presentation } from 'lucide-react';
 import { useState } from 'react';
+import { LectureFilters } from '@/components/lectures/lecture-filters';
 import CreateLectureDialog from './create-lecture-dialog';
 
-interface PageContentProps {
+interface LecturesPageContentProps {
   hasLectures: boolean;
 }
 
-export default function LecturesPageContent({ hasLectures }: PageContentProps) {
+export default function LecturesPageContent({
+  hasLectures,
+}: LecturesPageContentProps) {
   const [showCreateDialog, setShowCreateDialog] = useState(false);
-
-  const handleLectureCreated = () => {
-    setShowCreateDialog(false);
-  };
 
   if (!hasLectures) {
     return (
-      <>
+      <div className="flex-1">
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
             <Presentation className="mb-4 h-12 w-12 text-muted-foreground" />
@@ -36,25 +35,27 @@ export default function LecturesPageContent({ hasLectures }: PageContentProps) {
 
         <CreateLectureDialog
           onOpenChange={setShowCreateDialog}
-          onSuccess={handleLectureCreated}
+          onSuccess={() => setShowCreateDialog(false)}
           open={showCreateDialog}
         />
-      </>
+      </div>
     );
   }
 
   return (
     <>
-      <Button onClick={() => setShowCreateDialog(true)}>
-        <Plus className="mr-2 h-4 w-4" />
-        创建演讲
-      </Button>
-
-      <CreateLectureDialog
-        onOpenChange={setShowCreateDialog}
-        onSuccess={handleLectureCreated}
-        open={showCreateDialog}
-      />
+      <div className="flex items-center gap-2">
+        <Button onClick={() => setShowCreateDialog(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          创建演讲
+        </Button>
+        <CreateLectureDialog
+          onOpenChange={setShowCreateDialog}
+          onSuccess={() => setShowCreateDialog(false)}
+          open={showCreateDialog}
+        />
+      </div>
+      <LectureFilters />
     </>
   );
 }

--- a/apps/web/src/app/(dashboard)/lectures/page-content.tsx
+++ b/apps/web/src/app/(dashboard)/lectures/page-content.tsx
@@ -4,7 +4,6 @@ import { Button } from '@repo/ui/components/button';
 import { Card, CardContent } from '@repo/ui/components/card';
 import { Plus, Presentation } from 'lucide-react';
 import { useState } from 'react';
-import { LectureFilters } from '@/components/lectures/lecture-filters';
 import CreateLectureDialog from './create-lecture-dialog';
 
 interface LecturesPageContentProps {
@@ -41,21 +40,4 @@ export default function LecturesPageContent({
       </div>
     );
   }
-
-  return (
-    <>
-      <div className="flex items-center gap-2">
-        <Button onClick={() => setShowCreateDialog(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          创建演讲
-        </Button>
-        <CreateLectureDialog
-          onOpenChange={setShowCreateDialog}
-          onSuccess={() => setShowCreateDialog(false)}
-          open={showCreateDialog}
-        />
-      </div>
-      <LectureFilters />
-    </>
-  );
 }

--- a/apps/web/src/app/(dashboard)/lectures/page.tsx
+++ b/apps/web/src/app/(dashboard)/lectures/page.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@repo/ui/components/card';
+import { Skeleton } from '@repo/ui/components/skeleton';
 import {
   ArrowRight,
   Calendar,
@@ -17,6 +18,7 @@ import {
 import Link from 'next/link';
 import { Suspense } from 'react';
 import { getLectures } from '@/app/actions/lectures';
+import { LectureFilters } from '@/components/lectures/lecture-filters';
 import { lectureStatusConfig } from '@/types';
 import JoinCodeField from './join-code-field';
 import LecturesPageContent from './page-content';
@@ -27,21 +29,21 @@ function LecturesSkeleton() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <div className="mb-2 h-8 w-32 animate-pulse rounded bg-muted" />
-          <div className="h-4 w-64 animate-pulse rounded bg-muted" />
+          <Skeleton className="mb-2 h-8 w-32" />
+          <Skeleton className="h-4 w-64" />
         </div>
-        <div className="h-10 w-24 animate-pulse rounded bg-muted" />
+        <Skeleton className="h-10 w-24" />
       </div>
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {[1, 2, 3].map((i) => (
           <Card key={i}>
             <CardHeader>
-              <div className="h-6 w-3/4 animate-pulse rounded bg-muted" />
-              <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+              <Skeleton className="h-6 w-3/4" />
+              <Skeleton className="mt-2 h-4 w-1/2" />
             </CardHeader>
             <CardContent>
-              <div className="mb-2 h-4 w-full animate-pulse rounded bg-muted" />
-              <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+              <Skeleton className="mb-2 h-4 w-full" />
+              <Skeleton className="h-4 w-2/3" />
             </CardContent>
           </Card>
         ))}
@@ -71,8 +73,12 @@ function formatRelativeTime(dateStr: string) {
   });
 }
 
-async function LecturesList() {
-  const result = await getLectures();
+async function LecturesList({
+  status,
+}: {
+  status?: 'not_started' | 'in_progress' | 'paused' | 'ended';
+}) {
+  const result = await getLectures({ status });
 
   if (!(result.success && result.data) || result.data.data.length === 0) {
     return <LecturesPageContent hasLectures={false} />;
@@ -148,19 +154,29 @@ async function LecturesList() {
   );
 }
 
-export default function LecturesPage() {
+export const metadata = {
+  title: '我的演讲',
+};
+
+type LecturesPageProps = {
+  searchParams: {
+    status?: 'not_started' | 'in_progress' | 'paused' | 'ended';
+  };
+};
+
+export default function LecturesPage({ searchParams }: LecturesPageProps) {
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="font-bold text-2xl text-info">我的演讲</h1>
+          <h1 className="font-bold text-2xl">我的演讲</h1>
           <p className="text-muted-foreground">管理您创建的演讲会话</p>
         </div>
         <LecturesPageContent hasLectures={true} />
       </div>
-
+      <LectureFilters />
       <Suspense fallback={<LecturesSkeleton />}>
-        <LecturesList />
+        <LecturesList status={searchParams.status} />
       </Suspense>
     </div>
   );

--- a/apps/web/src/components/lectures/lecture-filters.tsx
+++ b/apps/web/src/components/lectures/lecture-filters.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Button } from '@repo/ui/components/button';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback } from 'react';
+import type { LectureStatus } from '@/types';
+
+type FilterOption = {
+  label: string;
+  value: LectureStatus | 'all';
+};
+
+const filterOptions: FilterOption[] = [
+  { label: '全部', value: 'all' },
+  { label: '进行中', value: 'in_progress' },
+  { label: '未开始', value: 'not_started' },
+  { label: '已结束', value: 'ended' },
+];
+
+export function LectureFilters() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentStatus = searchParams.get('status') || 'all';
+
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value === 'all') {
+        params.delete(name);
+      } else {
+        params.set(name, value);
+      }
+      // 当筛选条件改变时，重置到第一页
+      params.set('page', '1');
+      return params.toString();
+    },
+    [searchParams]
+  );
+
+  return (
+    <div className="flex items-center space-x-2">
+      <p className="font-medium text-muted-foreground text-sm">状态筛选:</p>
+      {filterOptions.map((option) => (
+        <Button
+          key={option.value}
+          onClick={() => {
+            router.push(`?${createQueryString('status', option.value)}`);
+          }}
+          size="sm"
+          variant={currentStatus === option.value ? 'default' : 'outline'}
+        >
+          {option.label}
+        </Button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
### 任务描述
- 在演讲列表页面添加快速筛选按钮组，让用户能够一键筛选"进行中"、"未开始"、"已结束"的演讲。这将帮助演讲者快速找到需要管理的演讲，特别是在演讲数量较多时。

### 具体要求
- 核心功能: 在演讲列表顶部添加状态筛选按钮组。
- 技术要点: 复用现有的 Button 组件和状态筛选逻辑。
- 验收标准: 点击筛选按钮后，列表只显示对应状态的演讲，支持"全部"选项。
